### PR TITLE
Slaveloan should not allow admin creation outside of "request" (yet)

### DIFF
--- a/relengapi/blueprints/slaveloan/templates/slaveloan_admin.html
+++ b/relengapi/blueprints/slaveloan/templates/slaveloan_admin.html
@@ -37,7 +37,7 @@
     <label for="status">Status: </label>
         <select name="status">
           <option>READY</option>
-          <option>PENDING</option>
+          <!-- XXX ToDo <option>PENDING</option> -->
         </select><br />
     <label for="LDAP">Full LDAP Username: </label>
         <input type="text" name="ldap_email" /><br />


### PR DESCRIPTION
This is because there is no mechanic to send along a machine/machine_type to the interface outside of the request. The request logic is also admin-only right now, so we'll use the admin form merely for "loan already done"