### PR TITLE
Don't comment out disable_machine_from_buildbot task

### DIFF
--- a/relengapi/blueprints/slaveloan/task_groups.py
+++ b/relengapi/blueprints/slaveloan/task_groups.py
@@ -18,8 +18,7 @@ def generate_loan(slavetype, loanid):
         group(
             tasks.fixup_machine.s(loanid=loanid),
             tasks.bmo_set_tracking_bug.s(loanid=loanid),
-            # disable_machine_from_buildbot(slavetype, loanid)
-            tasks.dummy_task.si(loanid=loanid)
+            disable_machine_from_buildbot(slavetype, loanid),
         ),
         group(
             manual_action(loanid=loanid, action_name="add_to_vpn"),


### PR DESCRIPTION
Commented out to facilitate testing, should be uncommented before initial deploy.

c.f. https://github.com/mozilla/build-relengapi-slaveloan/pull/8#discussion_r26506189