### PR TITLE
Ensure machine fqdn and IP is cached

### DIFF
--- a/relengapi/blueprints/slaveloan/tasks.py
+++ b/relengapi/blueprints/slaveloan/tasks.py
@@ -122,10 +122,14 @@ def fixup_machine(self, machine, loanid):
         m = Machines.as_unique(session,
                                fqdn=fqdn,
                                ipaddress=ipaddress)
+        #  Re-check validity of fqdn and ip
+        if m.fqdn != fqdn:
+            m.fqdn = fqdn
+        if m.ipaddress != ipaddress:
+            m.ipaddress = ipaddress
         l = session.query(Loans).get(loanid)
         l.machine = m
         session.commit()
-        l = session.query(Loans).get(loanid)
     except Exception as exc:  # pylint: disable=W0703
         logger.exception(exc)
         self.retry(exc=exc)


### PR DESCRIPTION
c.f. https://github.com/mozilla/build-relengapi-slaveloan/pull/8#issuecomment-81832067

We need to ensure the fqdn and ip of a machine gets updated when slaveloan runs, rather than always using a cached value.