### PR TITLE
Don't silently ignore new data for bugzilla e-mail

### DIFF
--- a/relengapi/blueprints/slaveloan/__init__.py
+++ b/relengapi/blueprints/slaveloan/__init__.py
@@ -115,6 +115,8 @@ def new_loan_from_admin(body):
                                    ipaddress=body.ipaddress)
         h = Humans.as_unique(session, ldap=body.LDAP,
                              bugzilla=body.bugzilla)
+        if h.bugzilla != body.bugzilla:
+            h.bugzilla = body.bugzilla
     except sa.exc.IntegrityError:
         raise InternalServerError("Integrity Error from Database, please retry.")
 
@@ -157,6 +159,8 @@ def new_loan_request(body):
     try:
         h = Humans.as_unique(session, ldap=body.ldap_email,
                              bugzilla=body.bugzilla_email)
+        if h.bugzilla != body.bugzilla_email:
+            h.bugzilla = body.bugzilla_email
     except sa.exc.IntegrityError:
         raise InternalServerError("Integrity Error from Database, please retry.")
 


### PR DESCRIPTION
c.f. https://github.com/mozilla/build-relengapi-slaveloan/pull/8#discussion_r26506875

Currently if a Bugzilla e-mail is passed and one already exists in DB, we completely ignore the passed value. We should either update, or at least warn.

My vote is update until/unless we have some better way to handle updating it.