### PR TITLE
AttributeError: 'LoanAdminRequest' object has no attribute 'LDAP'

### DIFF
--- a/relengapi/blueprints/slaveloan/__init__.py
+++ b/relengapi/blueprints/slaveloan/__init__.py
@@ -113,8 +113,8 @@ def new_loan_from_admin(body):
         if body.status != 'PENDING':
             m = Machines.as_unique(session, fqdn=body.fqdn,
                                    ipaddress=body.ipaddress)
-        h = Humans.as_unique(session, ldap=body.LDAP,
-                             bugzilla=body.bugzilla)
+        h = Humans.as_unique(session, ldap=body.ldap_email,
+                             bugzilla=body.bugzilla_email)
     except sa.exc.IntegrityError:
         raise InternalServerError("Integrity Error from Database, please retry.")
 


### PR DESCRIPTION
Traceback (most recent call last):
File "/data/www/relengapi/virtualenv/lib/python2.7/site-packages/flask/app.py", line 1475, in full_dispatch_request rv = self.dispatch_request()
File "/data/www/relengapi/virtualenv/lib/python2.7/site-packages/flask/app.py", line 1461, in dispatch_request return self.view_functions[rule.endpoint](**req.view_args)
File "/data/www/relengapi/virtualenv/lib/python2.7/site-packages/newrelic-2.46.0.37/newrelic/hooks/framework_flask.py", line 40, in _nr_wrapper_handler_ return wrapped(*args, **kwargs)
File "/data/www/relengapi/virtualenv/lib/python2.7/site-packages/relengapi/lib/permissions.py", line 85, in req return wrapped(*args, **kwargs)
File "/data/www/relengapi/virtualenv/lib/python2.7/site-packages/relengapi/lib/api.py", line 103, in replacement result = wrapped(*args, **kwargs)
File "/data/www/relengapi/virtualenv/lib/python2.7/site-packages/relengapi/blueprints/slaveloan/__init__.py", line 116, in new_loan_from_admin h = Humans.as_unique(session, ldap=body.LDAP,
AttributeError: 'LoanAdminRequest' object has no attribute 'LDAP'