### PR TITLE
Create bug references for already-ready loans

### DIFF
--- a/relengapi/blueprints/slaveloan/__init__.py
+++ b/relengapi/blueprints/slaveloan/__init__.py
@@ -118,11 +118,14 @@ def new_loan_from_admin(body):
     except sa.exc.IntegrityError:
         raise InternalServerError("Integrity Error from Database, please retry.")
 
+    loan_data = dict(status=body.status, human=h)
     if body.status != 'PENDING':
-        l = Loans(status=body.status, human=h, machine=m)
-    else:  # pragma: no-cover
-        # Not supported at this time
-        l = Loans(status=body.status, human=h)
+        loan_data.update(dict(machine=m))
+    if body.loan_bug_id:
+        loan_data.update(dict(bug_id=body.loan_bug_id))
+
+    l = Loans(**loan_data)
+
     history = History(for_loan=l,
                       timestamp=tz.utcnow(),
                       msg="%s added this entry to slave loan tool via admin interface" %

--- a/relengapi/blueprints/slaveloan/rest.py
+++ b/relengapi/blueprints/slaveloan/rest.py
@@ -87,6 +87,8 @@ class LoanAdminRequest(wsme.types.Base):
 
     #: Initial Status
     status = unicode
+    #: (optional) Loan Bug Id, if not passed in we create one for you
+    loan_bug_id = wsme.types.wsattr(int, mandatory=False)
     #: Users full LDAP e-mail
     ldap_email = unicode
     #: Users Bugzilla e-mail

--- a/relengapi/blueprints/slaveloan/static/slaveloan_admin.js
+++ b/relengapi/blueprints/slaveloan/static/slaveloan_admin.js
@@ -56,6 +56,7 @@ $(function() {
         };
 
         var form_status = form.find('select[name=status]').val();
+        var form_bug_id = form.find('input[name=bug_id]').val();
         var form_ldap = form.find('input[name=ldap_email]').val();
         var form_bmo = form.find('input[name=bugzilla_email]').val();
         var form_fqdn = form.find('input[name=fqdn]').val();
@@ -88,6 +89,7 @@ $(function() {
             type: 'POST',
             contentType: 'application/json; charset=utf-8',
             data: JSON.stringify({status: form_status,
+                                 loan_bug_id: parseInt(form_bug_id),
                                  ldap_email: form_ldap,
                                  bugzilla_email: form_bmo,
                                  fqdn: form_fqdn,

--- a/relengapi/blueprints/slaveloan/templates/slaveloan_admin.html
+++ b/relengapi/blueprints/slaveloan/templates/slaveloan_admin.html
@@ -39,6 +39,8 @@
           <option>ACTIVE</option>
           <!-- XXX ToDo <option>PENDING</option> -->
         </select><br />
+    <label for="bug_id">Bugzilla ID: </label>
+        <input type="text" name="bug_id" placeholder="<create new bug>" /><br />
     <label for="LDAP">Full LDAP Username: </label>
         <input type="text" name="ldap_email" /><br />
     <label for="bugzilla">Full Bugzilla E-mail: </label>


### PR DESCRIPTION
So, we need to populate bug info in already-ready loans, this provides us a means to do so.

Based on top of https://github.com/mozilla/build-relengapi-slaveloan/pull/58 merely to speed up travis results (will rebase once that one merges in, to keep git graph a bit saner).

@djmitche r?